### PR TITLE
Add fps metric for navigateRight scenario

### DIFF
--- a/customimagelistview.cpp
+++ b/customimagelistview.cpp
@@ -1310,6 +1310,9 @@ void CustomImageListView::navigateRight()
     NAV_LOG_EVENT(CustomNavLogger::NAV_RIGHT_START);
     NAV_LOG_PARAM(CustomNavLogger::NAV_RIGHT_START, m_currentIndex, "fromIndex", m_currentIndex);
 
+    // Start FPS measurement
+    startFpsMeasurement();
+
     QString currentCategory = m_imageData[m_currentIndex].category;
     int nextIndex = m_currentIndex + 1;
     
@@ -1351,6 +1354,10 @@ void CustomImageListView::navigateRight()
         
         ensureIndexVisible(nextIndex);
         update();
+
+        // Stop FPS measurement
+        stopFpsMeasurement();
+
         return;
     }
 
@@ -2621,4 +2628,25 @@ void CustomImageListView::updateMetricCounts(int nodes, int textures, qint64 tex
                  << "Textures:" << m_textureCount
                  << "Texture Memory:" << m_textureMemoryUsage << "bytes";
     }
+}
+
+void CustomImageListView::startFpsMeasurement()
+{
+    m_frameCount = 0;
+    m_startTime = QDateTime::currentMSecsSinceEpoch();
+    connect(window(), &QQuickWindow::frameSwapped, this, &CustomImageListView::onFrameSwapped);
+}
+
+void CustomImageListView::stopFpsMeasurement()
+{
+    disconnect(window(), &QQuickWindow::frameSwapped, this, &CustomImageListView::onFrameSwapped);
+    qint64 elapsedTime = QDateTime::currentMSecsSinceEpoch() - m_startTime;
+    qreal fps = (elapsedTime > 0) ? (m_frameCount * 1000.0 / elapsedTime) : 0.0;
+    qDebug() << "FPS during navigateRight:" << fps;
+    CustomNavLogger::instance().logEventWithParamFloat(CustomNavLogger::NAV_ANIM_COMPLETE, -1, "fps", fps);
+}
+
+void CustomImageListView::onFrameSwapped()
+{
+    m_frameCount++;
 }

--- a/customimagelistview.h
+++ b/customimagelistview.h
@@ -271,6 +271,10 @@ private:
     // Add this helper method for property validation
     bool checkAndCreateDynamicProperty(const QString& propName);
 
+    // Add member variables for fps measurement
+    int m_frameCount = 0;
+    qint64 m_startTime = 0;
+
 public:
     CustomImageListView(QQuickItem *parent = nullptr);
     ~CustomImageListView();
@@ -362,6 +366,10 @@ public:
 
     // Add method to calculate texture memory usage
     qint64 calculateTextureMemoryUsage() const;
+
+    // Add fps measurement methods
+    void startFpsMeasurement();
+    void stopFpsMeasurement();
 
 signals:
     void countChanged();


### PR DESCRIPTION
Add performance fps metric collection for navigateRight scenario.

* Add `startFpsMeasurement` and `stopFpsMeasurement` methods in `customimagelistview.cpp` to measure frames drawn during the animation.
* Modify `navigateRight` function in `customimagelistview.cpp` to call `startFpsMeasurement` at the beginning and `stopFpsMeasurement` at the end of the animation.
* Add member variables `m_frameCount` and `m_startTime` to `CustomImageListView` class in `customimagelistview.h`.
* Add method declarations for `startFpsMeasurement` and `stopFpsMeasurement` in `customimagelistview.h`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/prabhank/sceneGraph/pull/6?shareId=597c79c0-6e06-4b77-8b21-bb1d4dc004d3).